### PR TITLE
Chore/#6 change application.properties construct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
-/src/main/resources/application-dev.properties
-/src/main/resources/application-local.properties
+
+### .env ###
+.env

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,17 @@
+spring.config.import=optional:file:.env[.properties]
+
+spring.datasource.url=${LOCAL_DATASOURCE_URL}
+spring.datasource.username=${LOCAL_DATASOURCE_USERNAME}
+spring.datasource.password=${LOCAL_DATASOURCE_PASSWORD}
+
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+spring.jpa.hibernate.ddl-auto=create
+spring.sql.init.mode=never
+
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+
+aws.accessKeyId=${AWS_SES_KEY_ID}
+aws.secretAccessKey=${AWS_SES_SECRET_KEY}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,17 @@
+spring.config.import=optional:file:.env[.properties]
+
+server.port=${PROD_PORT}
+
+spring.datasource.url=${PROD_DATASOURCE_URL}
+spring.datasource.username=${PROD_DATASOURCE_USERNAME}
+spring.datasource.password=${PROD_DATASOURCE_PASSWORD}
+
+spring.jpa.hibernate.ddl-auto=none
+spring.sql.init.mode=never
+
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+
+aws.accessKeyId=${AWS_SES_KEY_ID}
+aws.secretAccessKey=${AWS_SES_SECRET_KEY}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,15 +1,3 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/kau_notifier
-spring.datasource.username=root
-spring.datasource.password=
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.application.name=kau_notifier
 
-# hibernate \uCFFC\uB9AC \uC124\uC815
-logging.level.org.hibernate.SQL=DEBUG
-logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-
-# data-local.sql, schema-local.sql \uC0AC\uC6A9
-spring.jpa.hibernate.ddl-auto=none
-spring.sql.init.mode=always
-
-spring.data.redis.host=localhost
-spring.data.redis.port=6379
+spring.profiles.default=dev


### PR DESCRIPTION
Resolve #6 

- `.env` 파일을 참조하도록 환경 변수 파일 구조를 변경하였습니다.
- 로컬에서 개발할 때는 `application-dev.properties`를 기본적으로 참조하도록 설정하였습니다.
- 실제 배포시에는 실행 옵션을 사용해 `application-prod.properties`를 참조하도록 하여 실행해야 합니다.